### PR TITLE
HIVE-[serde]: fixed flaky test testSerDeInnerNulls - sorted order

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Comparator;
 
 import org.apache.hadoop.hive.serde2.io.DateWritableV2;
 import org.apache.hadoop.hive.serde2.io.TimestampLocalTZWritable;
@@ -557,6 +558,7 @@ public final class ObjectInspectorUtils {
    */
   public static Field[] getDeclaredNonStaticFields(Class<?> c) {
     Field[] f = c.getDeclaredFields();
+    Arrays.sort(f, Comparator.comparing(Field::getName));
     ArrayList<Field> af = new ArrayList<Field>();
     for (int i = 0; i < f.length; ++i) {
       if (!Modifier.isStatic(f[i].getModifiers())) {

--- a/serde/src/test/org/apache/hadoop/hive/serde2/columnar/TestLazyBinaryColumnarSerDe.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/columnar/TestLazyBinaryColumnarSerDe.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.hive.serde2.columnar;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -234,7 +234,7 @@ public class TestLazyBinaryColumnarSerDe {
     outerStruct.mArray = new ArrayList<InnerStruct>(2);
     outerStruct.mArray.add(is1);
     outerStruct.mArray.add(is2);
-    outerStruct.mMap = new HashMap<String, InnerStruct>();
+    outerStruct.mMap = new LinkedHashMap<String, InnerStruct>();
     outerStruct.mMap.put(null, new InnerStruct(13, 14l));
     outerStruct.mMap.put(new String("fifteen"), null);
     outerStruct.mStruct = new InnerStruct(null, null);


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix 3 tests: 
```
org.apache.hadoop.hive.serde2.columnar.TestLazyBinaryColumnarSerDe.testSerDeInnerNulls
org.apache.hadoop.hive.serde2.columnar.TestLazyBinaryColumnarSerDe.testSerDeEmpties
org.apache.hadoop.hive.serde2.columnar.TestLazyBinaryColumnarSerDe.testLazyBinaryColumnarSerDeWithEmptyBinary
```

This flakiness was found by using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool.

1.  `ObjectInspectorUtils.getDeclaredNonStaticFields()` :  
      To ensure a consistent order, the field array was sorted.
 https://github.com/Sujishark/hive/blob/a18c734b41d0efc227a3e4e660d51089fb97b6a4/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java#L560-L561

2. `TestLazyBinaryColumnarSerDe.java`:
      Deserializing the serialized objects, included a HashMap, due to which the order wasn't maintained. This change aims to introduce a dependable sorting mechanism (HashMap to LinkedHashMap) for arranging the fields.

https://github.com/Sujishark/hive/blob/a18c734b41d0efc227a3e4e660d51089fb97b6a4/serde/src/test/org/apache/hadoop/hive/serde2/columnar/TestLazyBinaryColumnarSerDe.java#L237


### Why are the changes needed?

The test fails due to two reasons. 
First, when the 'ObjectInspector' is initialized in the first line of the `testSerDeInnerNulls()` (similar for other two tests). 

https://github.com/Sujishark/hive/blob/f88d77ba0a050c25303c0c7100758b069c07a783/serde/src/test/org/apache/hadoop/hive/serde2/columnar/TestLazyBinaryColumnarSerDe.java#L214-L215

This method drips down and makes call to 'getDeclaredNonStaticFields()' from where the field array created using `getDeclaredFields()` is returned. 

getDeclaredFields() states that 
> The elements in the array returned are not sorted and are not in any particular order.

https://github.com/Sujishark/hive/blob/f88d77ba0a050c25303c0c7100758b069c07a783/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java#L558-L559

Due to this, a ClassCastException occurs. This is solved by sorting the array elements.

Additionally, when using a `HashMap`, there is a discrepancy in the order of elements after serialization and deserialization. This issue can be resolved by using a `LinkedHashMap`.

### Does this PR introduce _any_ user-facing change?
No

### Is the change a dependency upgrade?
No

### How was this patch tested?
Tested using [Non-Dex](https://github.com/TestingResearchIllinois/NonDex) 

The following command can be used to replicate the failures and validate the fix:

```
mvn -pl serde edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.hadoop.hive.serde2.columnar.TestLazyBinaryColumnarSerDe#testSerDeInnerNulls
```

**Environment:**

> Java: openjdk version "11.0.20.1"
> Maven: Apache Maven 3.6.3
